### PR TITLE
Fix typo in runner name from 'ubutun' to 'ubuntu'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
   changeApproval:
     name: ServiceNow Change Approval
     needs: build
-    runs-on: ubutun-latest
+    runs-on: ubuntu-latest
 
     steps:     
       - name: ServiceNow Change Approval
@@ -55,7 +55,7 @@ jobs:
   deploy:
     name: Deploy
     needs: changeApproval
-    runs-on: ubutun-latest
+    runs-on: ubuntu-latest
 
     steps:     
       - name: Run Deployment Script


### PR DESCRIPTION
Description of the problem solved: Fix typo in runner name from 'ubutun' to 'ubuntu'
Acceptance criteria for how an approver can tell if the "story" was completed: code updated to correct 'ubutun'